### PR TITLE
Messages fetched by UID don't have $messageNum as key

### DIFF
--- a/src/Functions.php
+++ b/src/Functions.php
@@ -195,4 +195,22 @@ class Functions
     {
         return is_resource($imap) && get_resource_type($imap) == 'imap';
     }
+
+    public static function keyBy(string $name, array $list): array
+    {
+        $keyBy = [];
+        foreach ($list as $item) {
+            if (!isset($item->$name)) {
+                trigger_error('keyBy: key "' . $name . '" not found!', E_USER_WARNING);
+                continue;
+            }
+            if (isset($keyBy[$item->$name])) {
+                trigger_error('keyBy: duplicate key "' . $name . '" = "' . $item->$name . '"', E_USER_WARNING);
+                continue;
+            }
+            $keyBy[$item->$name] = $item;
+        }
+
+        return $keyBy;
+    }
 }

--- a/src/Message.php
+++ b/src/Message.php
@@ -165,6 +165,10 @@ class Message
 
         $messages = $client->fetch($imap->getMailboxName(), $messageNum, $isUid, ['BODY[TEXT]']);
 
+        if ($isUid && is_array($messages)) {
+            $messages = Functions::keyBy('uid', $messages);
+        }
+
         return $messages[$messageNum]->bodypart['TEXT'];
     }
 
@@ -184,6 +188,10 @@ class Message
             trigger_error(Errors::badMessageNumber(debug_backtrace(), 1), E_USER_WARNING);
 
             return false;
+        }
+
+        if ($isUid && is_array($messages)) {
+            $messages = Functions::keyBy('uid', $messages);
         }
 
         if ($section) {
@@ -215,6 +223,10 @@ class Message
 
         if (empty($messages)) {
             return "";
+        }
+
+        if ($isUid && is_array($messages)) {
+            $messages = Functions::keyBy('uid', $messages);
         }
 
         if ($section && isset($messages[$messageNum]->bodypart[$sectionKey])) {


### PR DESCRIPTION
First thanks to everyone involved in this project!

About the problem:
I'm using this library alongside with https://github.com/ddeboer/imap, which uses the UID to identify messages. In `Roundcube\ImapClient::fetch()` the sequence-number (variable `$id`) is used as the key in `$result`, even when `$is_uid` is set to true. In `Javanile\Imap2\Message` depending on `$flags` the `$messageNum`-parameter could either be the sequence-number or the UID. Therefore some methods fail to access the result.

What I've changed: 
~`array_pop()` is used to retrieve the message from the array and should work with sequence-numbers and UID.~
If FT_UID is set, `$messages` will have the `uid` as the key in the affected functions (no change was required to Roundcube).

How I've tested it:
I fetched mails from Outlook365 via OAuth2 and by UID successfully with this change.

Possibly related:
https://github.com/javanile/php-imap2/issues/15
https://github.com/javanile/php-imap2/issues/18